### PR TITLE
Add TypeScript declaration file through JSDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "babel-preset-stage-0": "^6.24.1",
         "lodash": "^4.17.11",
         "prettier": "1.17.0",
+        "typescript": "^4.7.4",
         "webpack": "^4.20.2",
         "webpack-cli": "^3.1.1"
       }
@@ -6202,6 +6203,19 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/uglify-es": {
       "version": "3.3.9",
@@ -12977,6 +12991,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "uglify-es": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.3.0",
   "description": "Swup scroll plugin.",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "lint": "prettier src/**/*.{js,mjs} --write",
-    "compile": "babel --presets es2015,stage-0 -d lib/ src/",
+    "types:generate": "npx tsc --allowJs -d --emitDeclarationOnly src/index.js",
+    "compile": "babel --presets es2015,stage-0 -d lib/ src/ && npm run types",
     "build": "webpack-cli",
     "prepublish": "npm run compile && npm run build"
   },
@@ -28,6 +30,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "lodash": "^4.17.11",
     "prettier": "1.17.0",
+    "typescript": "^4.7.4",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.1"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,151 @@
+/**
+ * Class representing the Swup Scroll Plugin.
+ * @extends Plugin
+ */
+export default class ScrollPlugin {
+    /**
+     * @typedef {object} animateScrollObject
+     * @property {boolean} [animateScrollObject.betweenPages]
+     * @property {boolean} [animateScrollObject.samePageWithHash]
+     * @property {boolean} [animateScrollObject.samePage]
+     */
+    /**
+     * Constructor
+     * @param {object} options
+     * @param {boolean} [options.doScrollingRightAway]
+     * @param {boolean|animateScrollObject} [options.animateScroll]
+     * @param {number} [options.scrollFriction]
+     * @param {number} [options.scrollAcceleration]
+     * @param {?function} [options.getAnchorElement]
+     * @param {number} [options.offset]
+     * @param {string} [options.scrollContainers]
+     * @param {function} [options.shouldResetScrollPosition]
+     */
+    constructor(options?: {
+        doScrollingRightAway?: boolean;
+        animateScroll?: boolean | {
+            betweenPages?: boolean;
+            samePageWithHash?: boolean;
+            samePage?: boolean;
+        };
+        scrollFriction?: number;
+        scrollAcceleration?: number;
+        getAnchorElement?: Function | null;
+        offset?: number;
+        scrollContainers?: string;
+        shouldResetScrollPosition?: Function;
+    });
+    name: string;
+    options: {};
+    scrollPositionsStore: {};
+    previousUrl: string;
+    /**
+     * Runs if the plugin is mounted
+     */
+    mount(): void;
+    scrl: any;
+    previousScrollRestoration: string;
+    /**
+     * Runs when the plugin is unmounted
+     */
+    unmount(): void;
+    /**
+     * Detects if a scroll should be animated, based on context
+     * @private
+     * @param {string} context
+     * @returns {boolean}
+     */
+    private shouldAnimate;
+    /**
+     * Get an element based on anchor
+     * @param {string} selector
+     * @returns {*}
+     */
+    getAnchorElement: (selector?: string) => any;
+    /**
+     * Get the offset for a scroll
+     * @param {?HTMLElement} element
+     * @returns {number}
+     */
+    getOffset: (element?: HTMLElement | null) => number;
+    /**
+     * Handles `samePage`
+     * @private
+     */
+    private onSamePage;
+    /**
+     * Handles `onSamePageWithHash`
+     * @private
+     * @param {PointerEvent} event
+     */
+    private onSamePageWithHash;
+    /**
+     * Attempts to scroll to an anchor
+     * @param {string} selector A selector string
+     * @param {string} context
+     * @returns {boolean}
+     */
+    maybeScrollToAnchor(selector: string, context: string): boolean;
+    /**
+     * Handles `transitionStart`
+     * @private
+     * @param {PopStateEvent} popstate
+     */
+    private onTransitionStart;
+    /**
+     * Handles `contentReplaced`
+     * @private
+     * @param {PopStateEvent} popstate
+     */
+    private onContentReplaced;
+    /**
+     * Scrolls the window, based on context
+     * @private
+     * @param {(PopStateEvent|boolean)} popstate
+     * @returns {void}
+     */
+    private doScrollingBetweenPages;
+    /**
+     * Stores the current scroll positions for the URL we just came from
+     * @private
+     */
+    private onWillReplaceContent;
+    /**
+     * Handles `clickLink`
+     * @private
+     * @param {PointerEvent} event
+     * @returns {void}
+     */
+    private onClickLink;
+    /**
+     * Deletes the scroll positions for the URL a link is pointing to,
+     * if shouldResetScrollPosition evaluates to true
+     * @private
+     * @param {HTMLAnchorElement} htmlAnchorElement
+     * @returns {void}
+     */
+    private maybeResetScrollPositions;
+    /**
+     * Stores the scroll positions for the current URL
+     * @param {string} url The URL you want to store the scroll positions for
+     * @returns {void}
+     */
+    storeScrollPositions(url: string): void;
+    /**
+     * Resets stored scroll positions for a given URL
+     * @param {string} url The URL you want to reset the scroll positions for
+     */
+    resetScrollPositions(url: string): void;
+    /**
+     * Get the stored scroll positions for a given URL from the cache
+     * @param {string} url The URL you want to get the scroll positions for
+     * @returns {?object}
+     */
+    getStoredScrollPositions(url: string): object | null;
+    /**
+     * Restore the scroll positions for all matching scrollContainers, for the current URL
+     * @param {(PopStateEvent|boolean)} popstate
+     * @returns void
+     */
+    restoreScrollContainers(popstate: (PopStateEvent | boolean)): void;
+}


### PR DESCRIPTION
Out of curiosity I gave this a try:

- installed typescript
- added an npm script `types:generate`:
```shell
npx tsc --allowJs -d --emitDeclarationOnly src/index.js
```
- almost bit my teeth trying to get the [JSDoc](https://jsdoc.app/) right for the plugin's nested options object 🤯😄

We should discuss if this is the right way to do it. The process JSDoc->tsc could become quite a big maintenance chore, I can imagine. How could we make sure it doesn't diverge from the actual code? I have the feeling that, if we want to support TS, we would have to rewrite the actual code to TypeScript. It feels like this wouldn't be more work then adding JSDoc.