### PR TITLE
Extract `getResolvedUrl` and use it where necessary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,10 +314,11 @@ export default class ScrollPlugin extends Plugin {
 
 	/**
 	 * Get the stored scroll positions for a given URL from the cache
-	 * @returns {(object|null)}
+	 * @returns {(object|undefined)}
 	 */
 	getStoredScrollPositions(url) {
-		return this.scrollPositionsStore[url];
+		const cacheKey = this.getResolvedUrl(url);
+		return this.scrollPositionsStore[cacheKey];
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -307,8 +307,9 @@ export default class ScrollPlugin extends Plugin {
 	 * @param {string} url
 	 */
 	resetScrollPositions(url) {
-		delete this.scrollPositionsStore[url];
-		this.scrollPositionsStore[url] = null;
+		const cacheKey = this.getResolvedUrl(url);
+		delete this.scrollPositionsStore[cacheKey];
+		this.scrollPositionsStore[cacheKey] = null;
 	}
 
 	/**
@@ -340,17 +341,20 @@ export default class ScrollPlugin extends Plugin {
 	}
 	/**
 	 * Get the current cache key for the scroll positions.
-	 * uses `getCurrentUrl` and applies `swup.resolveUrl` if present
-	 *
-	 * `swup.resolveUrl` will become available in Swup 3
-	 *
 	 * @returns {string}
 	 */
 	getCurrentCacheKey() {
-		const path = getCurrentUrl();
+		return this.getResolvedUrl(getCurrentUrl());
+	}
+	/**
+	* Apply `swup.resolveUrl` to a given URL
+	*
+	* @returns {string}
+	*/
+	getResolvedUrl(url) {
 		if (typeof this.swup.resolveUrl === 'function') {
-			return this.swup.resolveUrl(path);
+			return this.swup.resolveUrl(url);
 		}
-		return path;
+		return url;
 	}
 }


### PR DESCRIPTION
`resetScrollPositions` wasn't using the resolved version of a URL yet. This was leading to the scroll position for a page sometimes not being reset correctly. This PR fixes this.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)


