### PR TITLE
Allow to ignore the current page visit from the outside

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ import Scrl from 'scrl';
 export default class ScrollPlugin extends Plugin {
 	name = 'ScrollPlugin';
 
+	// Allows to ignore a page visit from the outside
+	ignorePageVisit = false;
+
 	/**
 	 * Constructor
 	 * @param {?object} options the plugin options
@@ -233,6 +236,12 @@ export default class ScrollPlugin extends Plugin {
 	 */
 	doScrollingBetweenPages = (popstate) => {
 		const swup = this.swup;
+
+		// Bail early if someone asked to ignore this page visit
+		if (this.ignorePageVisit) {
+			this.ignorePageVisit = false;
+			return;
+		}
 
 		// Bail early on popstate and inactive `animateHistoryBrowsing`
 		if (popstate && !swup.options.animateHistoryBrowsing) {


### PR DESCRIPTION
Related: #47

**Description**

For the new [Fragment Plugin](https://github.com/swup/fragment-plugin), we need a way to tell the Scroll Plugin to do nothing for the current page visit:

```js
/**
 * Disable the scroll plugin for fragment visits
 */
disableScrollPluginForCurrentVisit() {
	// We still want scrolling if there is a hash in the target link
	if (this.swup.scrollToElement) return;

	const scrollPlugin = this.swup.findPlugin('ScrollPlugin');
	if (scrollPlugin) scrollPlugin.ignorePageVisit = true;
}
```

Doing this would also help with #47 I suppose:

```js
swup.on('clickLink', (e) => {
  if (e.delegateTarget.matches('.ignore-me')) return;

  const scrollPlugin = swup.findPlugin('ScrollPlugin');
  if (scrollPlugin) scrollPlugin.ignorePageVisit = true;
})
```

A bit verbose but the most flexible I could come up with to be able to use if from another plugin.