### PR TITLE
Allow updating scroll target separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "scrl": "^2.0.0"
   },
   "peerDependencies": {
-    "swup": "^4.2.0"
+    "swup": "^4.0.0"
   },
   "browserslist": [
     "extends @swup/browserslist-config"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "scrl": "^2.0.0"
   },
   "peerDependencies": {
-    "swup": "^4.0.0"
+    "swup": "^4.2.0"
   },
   "browserslist": [
     "extends @swup/browserslist-config"

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import Scrl from 'scrl';
 export default class SwupScrollPlugin extends Plugin {
 	name = 'SwupScrollPlugin';
 
-	requires = { swup: '>=4.2' };
+	requires = { swup: '>=4' };
 
 	defaults = {
 		doScrollingRightAway: false,

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import Scrl from 'scrl';
 export default class SwupScrollPlugin extends Plugin {
 	name = 'SwupScrollPlugin';
 
-	requires = { swup: '>=4' };
+	requires = { swup: '>=4.2' };
 
 	defaults = {
 		doScrollingRightAway: false,

--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,8 @@ export default class SwupScrollPlugin extends Plugin {
 	 * Check whether to scroll in `visit:start` hook
 	 */
 	onVisitStart = (visit) => {
-		if (this.options.doScrollingRightAway && !visit.scroll.target) {
+		const scrollTarget = visit.scroll.target || visit.to.hash;
+		if (this.options.doScrollingRightAway && !scrollTarget) {
 			visit.scroll.scrolledToContent = true;
 			this.doScrollingBetweenPages(visit);
 		}
@@ -214,7 +215,8 @@ export default class SwupScrollPlugin extends Plugin {
 		}
 
 		// Try scrolling to a given anchor
-		if (this.maybeScrollToAnchor(visit.scroll.target, this.shouldAnimate('betweenPages'))) {
+		const scrollTarget = visit.scroll.target || visit.to.hash;
+		if (this.maybeScrollToAnchor(scrollTarget, this.shouldAnimate('betweenPages'))) {
 			return;
 		}
 


### PR DESCRIPTION
**Description**

- Allow setting `visit.scroll.target` without affecting the visible hash of the current URL

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~