### PR TITLE
Port to TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2248,9 +2248,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001449",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
-      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2259,6 +2259,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -7206,9 +7210,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001449",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
-      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw=="
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg=="
     },
     "chalk": {
       "version": "5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "scrl": "^2.0.0"
       },
       "peerDependencies": {
-        "swup": "^4.0.0"
+        "swup": "^4.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5391,9 +5391,9 @@
       }
     },
     "node_modules/swup": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/swup/-/swup-4.0.0.tgz",
-      "integrity": "sha512-GQX9WKFJBe4mZaryKkb8QZHsVP9u0GbMauD/B/msthNFB7rbUOqO1eSvaZB9d4TypHCjbviZ6kKac0v9vChOOA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/swup/-/swup-4.2.0.tgz",
+      "integrity": "sha512-z1ek0C9s1CgWJs63d0LxZCEVbZbU99b8I606pk2qVpkd6XtUOPI8Wcj7a4oh4StNZSKAsHbC07fbLmAIPI2MkQ==",
       "hasInstallScript": true,
       "dependencies": {
         "delegate-it": "^6.0.0",
@@ -9378,9 +9378,9 @@
       }
     },
     "swup": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/swup/-/swup-4.0.0.tgz",
-      "integrity": "sha512-GQX9WKFJBe4mZaryKkb8QZHsVP9u0GbMauD/B/msthNFB7rbUOqO1eSvaZB9d4TypHCjbviZ6kKac0v9vChOOA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/swup/-/swup-4.2.0.tgz",
+      "integrity": "sha512-z1ek0C9s1CgWJs63d0LxZCEVbZbU99b8I606pk2qVpkd6XtUOPI8Wcj7a4oh4StNZSKAsHbC07fbLmAIPI2MkQ==",
       "requires": {
         "delegate-it": "^6.0.0",
         "opencollective-postinstall": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,18 @@
   "version": "3.1.0",
   "description": "A swup plugin for customizable smooth scrolling",
   "type": "module",
-  "source": "src/index.js",
+  "source": "src/index.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",
-  "exports": "./dist/index.modern.js",
   "unpkg": "./dist/index.umd.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.modern.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "scrl": "^2.0.0"
   },
   "peerDependencies": {
-    "swup": "^4.0.0"
+    "swup": "^4.2.0"
   },
   "browserslist": [
     "extends @swup/browserslist-config"

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ declare module 'swup' {
 export default class SwupScrollPlugin extends Plugin {
 	name = 'SwupScrollPlugin';
 
-	requires = { swup: '>=4' };
+	requires = { swup: '>=4.2.0' };
 
 	scrl: any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,6 @@ export default class SwupScrollPlugin extends Plugin {
 
 		// This object will hold all scroll positions
 		this.scrollPositionsCache = {};
-		// this URL helps with storing the current scroll positions on `willReplaceContent`
-		this.currentCacheKey = this.getCurrentCacheKey();
 
 		// disable browser scroll control on popstates when
 		// animateHistoryBrowsing option is enabled in swup.
@@ -232,8 +230,13 @@ export default class SwupScrollPlugin extends Plugin {
 	 * Check whether to scroll in `visit:start` hook
 	 */
 	onVisitStart: Handler<'visit:start'> = (visit) => {
+		// this URL helps with storing the current scroll positions on `willReplaceContent`
+		this.currentCacheKey = this.getCurrentCacheKey();
+
 		const scrollTarget = visit.scroll.target || visit.to.hash;
+
 		visit.scroll.scrolledToContent = false;
+
 		if (this.options.doScrollingRightAway && !scrollTarget) {
 			visit.scroll.scrolledToContent = true;
 			this.doScrollingBetweenPages(visit);
@@ -281,23 +284,22 @@ export default class SwupScrollPlugin extends Plugin {
 	/**
 	 * Stores the current scroll positions for the URL we just came from
 	 */
-	onBeforeReplaceContent: Handler<"content:replace"> = () => {
+	onBeforeReplaceContent: Handler<'content:replace'> = () => {
 		this.storeScrollPositions(this.currentCacheKey!);
-		this.currentCacheKey = this.getCurrentCacheKey();
 	};
 
 	/**
 	 * Deletes the scroll positions for the URL a link is pointing to,
 	 * if shouldResetScrollPosition evaluates to true
 	 */
-	maybeResetScrollPositions: Handler<"visit:start"> = (visit: Visit): void => {
+	maybeResetScrollPositions: Handler<'visit:start'> = (visit: Visit): void => {
 		const { url } = visit.to;
 		const { el } = visit.trigger;
 		const shouldReset = !el || this.options.shouldResetScrollPosition(el);
 		if (shouldReset) {
 			this.resetScrollPositions(url);
 		}
-	}
+	};
 
 	/**
 	 * Stores the scroll positions for the current URL

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,10 +174,10 @@ export default class SwupScrollPlugin extends Plugin {
 		if (!el) return 0;
 		// If options.offset is a function, apply and return it
 		if (typeof this.options.offset === 'function') {
-			return Math.round(this.options.offset(el));
+			return parseInt(String(this.options.offset(el)), 10);
 		}
 		// Otherwise, return the sanitized offset
-		return Math.round(this.options.offset);
+		return parseInt(String(this.options.offset), 10);
 	};
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ export default class SwupScrollPlugin extends Plugin {
 		if (!el) return;
 
 		if (this.options.shouldResetScrollPosition(el)) {
-			this.resetScrollPositions(url)
+			this.resetScrollPositions(url);
 		}
 	};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export type Options = {
 	getAnchorElement?: (hash: string) => Element | null;
 	offset: number | ((el: Element) => number);
 	scrollContainers: `[data-swup-scroll-container]`;
-	shouldResetScrollPosition: (link: Element) => true;
+	shouldResetScrollPosition: (trigger: Element) => boolean;
 };
 
 type ScrollPosition = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,9 @@ export default class SwupScrollPlugin extends Plugin {
 			window.history.scrollRestoration = 'manual';
 		}
 
+		// this URL helps with storing the current scroll positions on `willReplaceContent`
+		this.currentCacheKey = this.getCurrentCacheKey();
+
 		// scroll to the top of the page when a visit starts, before replacing the content
 		this.on('visit:start', this.onVisitStart);
 
@@ -233,9 +236,6 @@ export default class SwupScrollPlugin extends Plugin {
 
 		visit.scroll.scrolledToContent = false;
 
-		// this URL helps with storing the current scroll positions on `willReplaceContent`
-		this.currentCacheKey = this.getCurrentCacheKey();
-
 		if (this.options.doScrollingRightAway && !scrollTarget) {
 			visit.scroll.scrolledToContent = true;
 			this.doScrollingBetweenPages(visit);
@@ -285,6 +285,7 @@ export default class SwupScrollPlugin extends Plugin {
 	 */
 	onBeforeReplaceContent: Handler<'content:replace'> = () => {
 		this.cacheScrollPositions(this.currentCacheKey!);
+		this.currentCacheKey = this.getCurrentCacheKey();
 	};
 
 	/**
@@ -295,10 +296,11 @@ export default class SwupScrollPlugin extends Plugin {
 		const { url } = visit.to;
 		const { el } = visit.trigger;
 
-		/**	Bail early if no trigger element or the scroll positions shouldn't be reset for the element */
-		if ( !el || !this.options.shouldResetScrollPosition(el)) return;
+		if (!el) return;
 
-		this.resetScrollPositions(url);
+		if (this.options.shouldResetScrollPosition(el)) {
+			this.resetScrollPositions(url)
+		}
 	};
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,14 +117,8 @@ export default class SwupScrollPlugin extends Plugin {
 			window.history.scrollRestoration = 'manual';
 		}
 
-		// this URL helps with storing the current scroll positions on `willReplaceContent`
-		this.currentCacheKey = this.getCurrentCacheKey();
-
 		// scroll to the top of the page when a visit starts, before replacing the content
 		this.on('visit:start', this.onVisitStart);
-
-		// cache the current scroll positions before replacing the content
-		this.before('content:replace', this.onBeforeReplaceContent);
 
 		// scroll to the top or target element after replacing the content
 		this.replace('content:scroll', this.onScrollToContent);
@@ -231,6 +225,7 @@ export default class SwupScrollPlugin extends Plugin {
 	 */
 	onVisitStart: Handler<'visit:start'> = (visit) => {
 		this.maybeResetScrollPositions(visit);
+		this.cacheScrollPositions(visit.from.url);
 
 		const scrollTarget = visit.scroll.target || visit.to.hash;
 
@@ -281,14 +276,6 @@ export default class SwupScrollPlugin extends Plugin {
 	};
 
 	/**
-	 * Stores the current scroll positions for the URL we just came from
-	 */
-	onBeforeReplaceContent: Handler<'content:replace'> = () => {
-		this.cacheScrollPositions(this.currentCacheKey!);
-		this.currentCacheKey = this.getCurrentCacheKey();
-	};
-
-	/**
 	 * Resets cached scroll positions for visits with a trigger element,
 	 * where shouldResetScrollPosition returns true for that trigger
 	 */
@@ -296,9 +283,7 @@ export default class SwupScrollPlugin extends Plugin {
 		const { url } = visit.to;
 		const { el } = visit.trigger;
 
-		if (!el) return;
-
-		if (this.options.shouldResetScrollPosition(el)) {
+		if (el && this.options.shouldResetScrollPosition(el)) {
 			this.resetScrollPositions(url);
 		}
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,7 @@ export default class SwupScrollPlugin extends Plugin {
 		}
 
 		// Finally, scroll to either the stored scroll position or to the very top of the page
-		const scrollPositions = this.getCachedScrollPositions(this.getCurrentCacheKey());
+		const scrollPositions = this.getCachedScrollPositions(this.swup.resolveUrl(getCurrentUrl()));
 		const top = scrollPositions?.window?.top || 0;
 
 		// Give possible JavaScript time to execute before scrolling
@@ -342,10 +342,4 @@ export default class SwupScrollPlugin extends Plugin {
 		});
 	}
 
-	/**
-	 * Get the current cache key for the scroll positions.
-	 */
-	getCurrentCacheKey(): string {
-		return this.swup.resolveUrl(getCurrentUrl());
-	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "moduleResolution": "Node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
+    "rootDirs": ["./src"],                               /* Allow multiple folders to be treated as one when resolving modules. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
+    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "include": ["src"],
   "compilerOptions": {
-    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "moduleResolution": "Node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
-    "rootDirs": ["./src"],                               /* Allow multiple folders to be treated as one when resolving modules. */
-    "resolveJsonModule": true,                           /* Enable importing .json files. */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "moduleResolution": "Node16" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "rootDirs": ["./src"] /* Allow multiple folders to be treated as one when resolving modules. */,
+    "resolveJsonModule": true /* Enable importing .json files. */,
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */
   }
 }


### PR DESCRIPTION
**Description**

Port to TypeScript

**Notes**

- [scrl has a PR waiting for TypeScript](https://github.com/gmrchk/scrl). Until then, I'm using `any` for it.
- `npm run format` still alerts `[warn] jsxBracketSameLine is deprecated`. I don't know why, thought there was an update implemented for this some time ago.
- I decided to bump both the `peerDependency` as well as `requires` for swup to `^4.2.0`. That way, `visit.to.hash` should actually be available in `doScrollingBetweenPages`.

**Drive-By**

- Bug-fix: `maybeResetScrollPositions` was always resetting the scroll position. Should now correctly respect `options.shouldResetScrollPosition` (tested manually in playground).

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`) Tested this by running the swup plugin tests with a compiled umd-version of this branch
