### PR TITLE
Save scroll animation status in visit object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ export default class SwupScrollPlugin extends Plugin {
 		this.on('visit:start', this.onVisitStart);
 
 		// scroll to the top or target element after replacing the content
-		this.replace('content:scroll', this.onScrollToContent);
+		this.replace('content:scroll', this.handleScrollToContent);
 
 		// scroll to the top of the page
 		this.replace('scroll:top', this.handleScrollToTop);
@@ -244,7 +244,7 @@ export default class SwupScrollPlugin extends Plugin {
 	/**
 	 * Check whether to scroll in `content:scroll` hook
 	 */
-	onScrollToContent: Handler<'content:scroll'> = (visit) => {
+	handleScrollToContent: Handler<'content:scroll'> = (visit) => {
 		if (!visit.scroll.scrolledToContent) {
 			this.doScrollingBetweenPages(visit);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,6 @@ import { Handler, Visit, getCurrentUrl, queryAll } from 'swup';
 // @ts-expect-error
 import Scrl from 'scrl';
 
-declare module 'swup' {
-	export interface VisitScroll {
-
-	}
-}
-
 export type Options = {
 	doScrollingRightAway: boolean;
 	animateScroll: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,15 @@ export default class SwupScrollPlugin extends Plugin {
 		this.cacheScrollPositions(visit.from.url);
 
 		const scrollTarget = visit.scroll.target ?? visit.to.hash;
-		if (this.options.doScrollingRightAway && !scrollTarget) {
+
+		// Conditions for scrolling before content replace:
+		// - scroll is animated (otherwise the effect is useless)
+		// - no scroll target is defined (needs to wait until new content is there)
+		if (
+			visit.scroll.animate &&
+			this.options.doScrollingRightAway &&
+			!scrollTarget
+		) {
 			this.doScrollingBetweenPages(visit);
 		}
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,11 +260,7 @@ export default class SwupScrollPlugin extends Plugin {
 		// Conditions for scrolling before content replace:
 		// - scroll is animated (otherwise the effect is useless)
 		// - no scroll target is defined (needs to wait until new content is there)
-		if (
-			visit.scroll.animate &&
-			this.options.doScrollingRightAway &&
-			!scrollTarget
-		) {
+		if (visit.scroll.animate && this.options.doScrollingRightAway && !scrollTarget) {
 			this.doScrollingBetweenPages(visit);
 		}
 	};
@@ -375,5 +371,4 @@ export default class SwupScrollPlugin extends Plugin {
 			el.scrollLeft = scrollPosition.left;
 		});
 	}
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,24 +9,6 @@ declare module 'swup' {
 	}
 }
 
-declare module 'swup' {
-	export interface Swup {
-		scrollTo?: (offset: number, animate?: boolean) => void;
-	}
-
-	export interface VisitScroll {
-		/** Whether scrolling is animated. Set by Scroll Plugin. */
-		animate?: boolean;
-		/** Whether the scroll position was reset after page load. Set by Scroll Plugin. */
-		scrolledToContent?: boolean;
-	}
-
-	export interface HookDefinitions {
-		'scroll:start': {};
-		'scroll:end': {};
-	}
-}
-
 export type Options = {
 	doScrollingRightAway: boolean;
 	animateScroll: {
@@ -53,6 +35,24 @@ type ScrollPositionsCacheEntry = {
 };
 
 type ScrollPositionsCache = Record<string, ScrollPositionsCacheEntry>;
+
+declare module 'swup' {
+	export interface Swup {
+		scrollTo?: (offset: number, animate?: boolean) => void;
+	}
+
+	export interface VisitScroll {
+		/** Whether scrolling is animated. Set by Scroll Plugin. */
+		animate?: boolean;
+		/** Whether the scroll position was reset after page load. Set by Scroll Plugin. */
+		scrolledToContent?: boolean;
+	}
+
+	export interface HookDefinitions {
+		'scroll:start': {};
+		'scroll:end': {};
+	}
+}
 
 /**
  * Scroll Plugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,11 +127,11 @@ export default class SwupScrollPlugin extends Plugin {
 		this.replace('content:scroll', this.handleScrollToContent);
 
 		// scroll to the top of the same page
-		this.before('link:self', this.onBeforeLinkToSelf);
+		this.before('link:self', this.onBeforeLinkToSelf, { priority: -1 });
 		this.replace('scroll:top', this.handleScrollToTop);
 
 		// scroll to an anchor on the same page
-		this.before('link:anchor', this.onBeforeLinkToAnchor);
+		this.before('link:anchor', this.onBeforeLinkToAnchor, { priority: -1 });
 		this.replace('scroll:anchor', this.handleScrollToAnchor);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,13 +246,11 @@ export default class SwupScrollPlugin extends Plugin {
 		this.maybeResetScrollPositions(visit);
 		this.cacheScrollPositions(visit.from.url);
 
-		const scrollTarget = visit.scroll.target ?? visit.to.hash;
-
 		visit.scroll.scrolledToContent = false;
 		visit.scroll.animate = this.shouldAnimate('betweenPages');
 
+		const scrollTarget = visit.scroll.target ?? visit.to.hash;
 		if (this.options.doScrollingRightAway && !scrollTarget) {
-			visit.scroll.scrolledToContent = true;
 			this.doScrollingBetweenPages(visit);
 		}
 	};
@@ -277,8 +275,8 @@ export default class SwupScrollPlugin extends Plugin {
 		}
 
 		// Try scrolling to a given anchor
-		const scrollTarget = visit.scroll.target || visit.to.hash;
-		if (this.maybeScrollToAnchor(scrollTarget, visit.scroll.animate)) {
+		const scrollTarget = visit.scroll.target ?? visit.to.hash;
+		if (scrollTarget && this.maybeScrollToAnchor(scrollTarget, visit.scroll.animate)) {
 			return;
 		}
 
@@ -286,6 +284,8 @@ export default class SwupScrollPlugin extends Plugin {
 		if (!visit.scroll.reset) {
 			return;
 		}
+
+		visit.scroll.scrolledToContent = true;
 
 		// Finally, scroll to either the stored scroll position or to the very top of the page
 		const scrollPositions = this.getCachedScrollPositions(this.swup.resolveUrl(getCurrentUrl()));


### PR DESCRIPTION
**Description**

- Add a `visit.scroll.animate` key and use it to determine whether to animate scrolling or not
- Allow disabling scroll animations via the visit object
- Will be used in an upcoming [prefers-reduced-motion feature](https://github.com/swup/a11y-plugin/pull/24) of the Accessibility Plugin

**Drive-by improvement**

- Fix same [scroll reset issue](https://github.com/swup/swup/pull/768) fixed in core recently
- Make second `animate` argument of `swup.scrollTo()` optional
- Rename scroll handler for consistency

**How to disable scroll animations**

```js
// Disable scroll animation between pages
swup.hooks.before('visit:start', (visit) => visit.scroll.animate  = false)

// Disable scroll animation on link to same page
swup.hooks.before('link:self', (visit) => visit.scroll.animate  = false)

// Disable scroll animation on link to same page anchor
swup.hooks.before('link:anchor', (visit) => visit.scroll.animate  = false)
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)

**Additional information**

Closes #63
