### PR TITLE
Fix scrolling before transition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,7 @@ export default class SwupScrollPlugin extends Plugin {
 		}
 
 		// Finally, scroll to either the stored scroll position or to the very top of the page
-		const scrollPositions = this.getCachedScrollPositions(this.swup.resolveUrl(visit.to.url));
+		const scrollPositions = this.getCachedScrollPositions(visit.to.url);
 		const top = scrollPositions?.window?.top || 0;
 
 		// Give possible JavaScript time to execute before scrolling

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,7 @@ export default class SwupScrollPlugin extends Plugin {
 		}
 
 		// Finally, scroll to either the stored scroll position or to the very top of the page
-		const scrollPositions = this.getCachedScrollPositions(this.swup.resolveUrl(getCurrentUrl()));
+		const scrollPositions = this.getCachedScrollPositions(this.swup.resolveUrl(visit.to.url));
 		const top = scrollPositions?.window?.top || 0;
 
 		// Give possible JavaScript time to execute before scrolling


### PR DESCRIPTION
**Description**

- Currently, the `doScrollingRightAway` option is broken
- It restores the scroll position from `getCurrentUrl()`, which is still the old URL before the transition
- Effectively, this means that the scroll position is not reset on any visit
- Switching to `visit.to.url` solves the issue
- Also removed a duplicate `resolveUrl` when passing in the URL, it's resolved inside the helper again anyway

**Before**

https://github.com/swup/scroll-plugin/assets/22225348/2ba1acdf-8e7e-49aa-9700-8ce97b2a842c

**After**

https://github.com/swup/scroll-plugin/assets/22225348/e4b12b66-3c94-4666-99ba-155911abf4b8

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
