### PR TITLE
Fix scroll reset logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -282,10 +282,10 @@ export default class SwupScrollPlugin extends Plugin {
 	maybeResetScrollPositions = (visit: Visit): void => {
 		const { url } = visit.to;
 		const { el } = visit.trigger;
-
-		if (el && this.options.shouldResetScrollPosition(el)) {
-			this.resetScrollPositions(url);
+		if (el && !this.options.shouldResetScrollPosition(el)) {
+			return;
 		}
+		this.resetScrollPositions(url);
 	};
 
 	/**


### PR DESCRIPTION
**Description**

- Currently, the scroll position is only reset when clicking links
- Navigating via the API will not reset scroll positions
- We kind of garbled up the logic in `maybeResetScrollPositions`
- At the moment, it only resets if there is a trigger element AND it returns true for resetting
- The logic should be:
  - if there is a trigger element (link visit) and it returns false, do nothing = return early
  - otherwise, go through and reset (= no link or link returns true per default)

**Before**

https://github.com/swup/scroll-plugin/assets/22225348/0fa42f86-f1c5-4888-8345-f0b8fc31758b

**After**

https://github.com/swup/scroll-plugin/assets/22225348/396f08b3-9969-4e7e-b3cc-cb665bc4e4bd

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)