### PR TITLE
Emulate scroll :target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A [swup](https://swup.js.org) plugin for customizable smooth scrolling.
 - Animates scroll position between page visits
 - Animates scrolling to anchors
 - Define a custom offset for scroll positions
+- Emulate scroll target selector
 
 ## Installation
 
@@ -115,6 +116,27 @@ Customize how the scroll target is found on the page. Defaults to standard brows
 }
 ```
 
+### markScrollTarget
+
+Due to [certain limitations](https://github.com/whatwg/html/issues/639) of the History API,
+the [`:target` CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:target) stops
+working on sites that push their own history entries, which includes any site using swup. Enabling
+this option provides an alternative way of styling the current target element.
+
+Navigating to the URL `/index.html#section2` will make the following element the target element:
+
+```html
+<section id="section2">Example</section>
+```
+
+To highlight the current target element, use the `data-swup-scroll-target` attribute for styling:
+
+```css
+[data-swup-scroll-target] {
+  outline: 5px auto blue;
+}
+```
+
 ### Offset
 
 Offset to substract from the final scroll position, to account for fixed headers. Can be either a number or a function that returns the offset.
@@ -171,6 +193,7 @@ new SwupScrollPlugin({
   scrollFriction: 0.3,
   scrollAcceleration: 0.04,
   getAnchorElement: null,
+  markScrollTarget: false,
   offset: 0,
   scrollContainers: `[data-swup-scroll-container]`,
   shouldResetScrollPosition: (link) => true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import Plugin from '@swup/plugin';
-import { Handler, Visit, getCurrentUrl, queryAll } from 'swup';
+import { Handler, Visit, queryAll } from 'swup';
 // @ts-expect-error
 import Scrl from 'scrl';
 
@@ -16,6 +16,7 @@ export type Options = {
 	offset: number | ((el: Element) => number);
 	scrollContainers: `[data-swup-scroll-container]`;
 	shouldResetScrollPosition: (trigger: Element) => boolean;
+	markScrollTarget?: boolean;
 };
 
 type ScrollPosition = {
@@ -70,7 +71,8 @@ export default class SwupScrollPlugin extends Plugin {
 		getAnchorElement: undefined,
 		offset: 0,
 		scrollContainers: `[data-swup-scroll-container]`,
-		shouldResetScrollPosition: () => true
+		shouldResetScrollPosition: () => true,
+		markScrollTarget: false
 	};
 
 	options: Options;
@@ -120,6 +122,14 @@ export default class SwupScrollPlugin extends Plugin {
 			window.history.scrollRestoration = 'manual';
 		}
 
+		/**
+		 * Mark the current scroll target element with a `data-swup-scroll-target` attribute
+		 */
+		this.updateScrollTarget = this.updateScrollTarget.bind(this);
+		this.on('page:view', this.updateScrollTarget);
+		window.addEventListener('popstate', this.updateScrollTarget);
+		window.addEventListener('hashchange', this.updateScrollTarget);
+
 		// scroll to the top of the page when a visit starts, before replacing the content
 		this.before('visit:start', this.onBeforeVisitStart, { priority: -1 });
 		this.on('visit:start', this.onVisitStart, { priority: 1 });
@@ -145,6 +155,9 @@ export default class SwupScrollPlugin extends Plugin {
 		if (this.previousScrollRestoration) {
 			window.history.scrollRestoration = this.previousScrollRestoration;
 		}
+
+		window.removeEventListener('popstate', this.updateScrollTarget, false);
+		window.removeEventListener('hashchange', this.updateScrollTarget, false);
 
 		this.cachedScrollPositions = {};
 		delete this.swup.scrollTo;
@@ -370,5 +383,16 @@ export default class SwupScrollPlugin extends Plugin {
 			el.scrollTop = scrollPosition.top;
 			el.scrollLeft = scrollPosition.left;
 		});
+	}
+
+	updateScrollTarget(): void {
+		const { hash } = window.location;
+		const currentTarget = document.querySelector('[data-swup-scroll-target]');
+		const newTarget = this.getAnchorElement(hash);
+		if (currentTarget === newTarget) {
+			return;
+		}
+		currentTarget?.removeAttribute('data-swup-scroll-target');
+		newTarget?.setAttribute('data-swup-scroll-target', '');
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,8 +161,8 @@ export default class SwupScrollPlugin extends Plugin {
 			window.history.scrollRestoration = this.previousScrollRestoration;
 		}
 
-		window.removeEventListener('popstate', this.updateScrollTarget, false);
-		window.removeEventListener('hashchange', this.updateScrollTarget, false);
+		window.removeEventListener('popstate', this.updateScrollTarget);
+		window.removeEventListener('hashchange', this.updateScrollTarget);
 
 		this.cachedScrollPositions = {};
 		delete this.swup.scrollTo;

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,14 @@ export default class SwupScrollPlugin extends Plugin {
 		 * Mark the current scroll target element with a `data-swup-scroll-target` attribute
 		 */
 		this.updateScrollTarget = this.updateScrollTarget.bind(this);
-		this.on('page:view', this.updateScrollTarget);
-		window.addEventListener('popstate', this.updateScrollTarget);
-		window.addEventListener('hashchange', this.updateScrollTarget);
+		if (this.options.markScrollTarget) {
+			window.addEventListener('popstate', this.updateScrollTarget);
+			window.addEventListener('hashchange', this.updateScrollTarget);
+			this.on('page:view', this.updateScrollTarget);
+			this.on('link:anchor', this.updateScrollTarget);
+			this.on('link:self', this.updateScrollTarget);
+			this.updateScrollTarget();
+		}
 
 		// scroll to the top of the page when a visit starts, before replacing the content
 		this.before('visit:start', this.onBeforeVisitStart, { priority: -1 });
@@ -388,7 +393,11 @@ export default class SwupScrollPlugin extends Plugin {
 	updateScrollTarget(): void {
 		const { hash } = window.location;
 		const currentTarget = document.querySelector('[data-swup-scroll-target]');
-		const newTarget = this.getAnchorElement(hash);
+		let newTarget = this.getAnchorElement(hash);
+		if (newTarget instanceof HTMLBodyElement) {
+			// Special case: '#top' fragment returns <body> element
+			newTarget = null;
+		}
 		if (currentTarget === newTarget) {
 			return;
 		}


### PR DESCRIPTION
**Description**

- Emulate native `:target` selector that stops working when updating URLs via History API
- Introduce a setting `markScrollTarget` to mark targets  with a `data-swup-scroll-target` attribute
- Waiting on [PR #772](https://github.com/swup/swup/pull/772) on the core to work properly

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

**Additional information**

Closes #53 