### PR TITLE
Fix scroll position restoration on history visits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -324,12 +324,17 @@ export default class SwupScrollPlugin extends Plugin {
 	};
 
 	/**
-	 * Resets cached scroll positions for visits with a trigger element,
-	 * where shouldResetScrollPosition returns true for that trigger
+	 * Reset cached scroll positions. Do not reset if:
+	 * - the visit is a history visit
+	 * - the visit is triggered by a link and shouldResetScrollPosition(link) returns false
 	 */
 	maybeResetScrollPositions = (visit: Visit): void => {
+		const { popstate } = visit.history;
 		const { url } = visit.to;
 		const { el } = visit.trigger;
+		if (popstate) {
+			return;
+		}
 		if (el && !this.options.shouldResetScrollPosition(el)) {
 			return;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,6 +345,8 @@ export default class SwupScrollPlugin extends Plugin {
 	 * Stores the scroll positions for the current URL
 	 */
 	cacheScrollPositions(url: string): void {
+		const cacheKey = this.swup.resolveUrl(url);
+
 		// retrieve the current scroll position for all containers
 		const containers = queryAll(this.options.scrollContainers).map((el) => ({
 			top: el.scrollTop,
@@ -357,7 +359,7 @@ export default class SwupScrollPlugin extends Plugin {
 			containers
 		};
 
-		this.cachedScrollPositions[url] = positions;
+		this.cachedScrollPositions[cacheKey] = positions;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,8 +270,8 @@ export default class SwupScrollPlugin extends Plugin {
 	 * Check whether to scroll in `visit:start` hook
 	 */
 	onVisitStart: Handler<'visit:start'> = (visit) => {
-		this.maybeResetScrollPositions(visit);
 		this.cacheScrollPositions(visit.from.url);
+		this.maybeResetScrollPositions(visit);
 
 		const scrollTarget = visit.scroll.target ?? visit.to.hash;
 


### PR DESCRIPTION
**Description**

- When investigating this [issue about scroll restoration](https://github.com/swup/scroll-plugin/issues/57), I've found that popstate restoration isn't working when `animateHistoryBrowsing` is enabled
- The current implementation will reset the scroll position before each visit, thus always forcing a scroll to top for all history visits as well
- The issue is solved by not resetting the position on history visits

With these changes, the following example will now correctly always scroll history visits to the top:

```js
swup.hooks.on('visit:start', (visit) => {
  if (visit.history.popstate) {
    visit.scroll.target = '#top'
  }
})
```

**Drive-by improvements**

- Apply `resolveUrl` also when caching scroll positions
- Reorder position cache/reset: cache first, then reset, to cover cases of visits to the current URL

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

Closes #57 