### PR TITLE
Add hook args to `callSync` calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ declare module 'swup' {
 	}
 
 	export interface HookDefinitions {
-		'scroll:start': {};
-		'scroll:end': {};
+		'scroll:start'?: {};
+		'scroll:end'?: {};
 	}
 }
 
@@ -94,9 +94,9 @@ export default class SwupScrollPlugin extends Plugin {
 
 		// Initialize Scrl lib for smooth animations
 		this.scrl = new Scrl({
-			onStart: () => swup.hooks.callSync('scroll:start', {}),
-			onEnd: () => swup.hooks.callSync('scroll:end', {}),
-			onCancel: () => swup.hooks.callSync('scroll:end', {}),
+			onStart: () => swup.hooks.callSync('scroll:start', undefined),
+			onEnd: () => swup.hooks.callSync('scroll:end', undefined),
+			onCancel: () => swup.hooks.callSync('scroll:end', undefined),
 			friction: this.options.scrollFriction,
 			acceleration: this.options.scrollAcceleration
 		});
@@ -106,9 +106,9 @@ export default class SwupScrollPlugin extends Plugin {
 			if (animate) {
 				this.scrl.scrollTo(offset);
 			} else {
-				swup.hooks.callSync('scroll:start', {});
+				swup.hooks.callSync('scroll:start', undefined);
 				window.scrollTo(0, offset);
-				swup.hooks.callSync('scroll:end', {});
+				swup.hooks.callSync('scroll:end', undefined);
 			}
 		};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ declare module 'swup' {
 	}
 
 	export interface HookDefinitions {
-		'scroll:start'?: {};
-		'scroll:end'?: {};
+		'scroll:start': undefined;
+		'scroll:end': undefined;
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,9 +94,9 @@ export default class SwupScrollPlugin extends Plugin {
 
 		// Initialize Scrl lib for smooth animations
 		this.scrl = new Scrl({
-			onStart: () => swup.hooks.callSync('scroll:start'),
-			onEnd: () => swup.hooks.callSync('scroll:end'),
-			onCancel: () => swup.hooks.callSync('scroll:end'),
+			onStart: () => swup.hooks.callSync('scroll:start', {}),
+			onEnd: () => swup.hooks.callSync('scroll:end', {}),
+			onCancel: () => swup.hooks.callSync('scroll:end', {}),
 			friction: this.options.scrollFriction,
 			acceleration: this.options.scrollAcceleration
 		});
@@ -106,9 +106,9 @@ export default class SwupScrollPlugin extends Plugin {
 			if (animate) {
 				this.scrl.scrollTo(offset);
 			} else {
-				swup.hooks.callSync('scroll:start');
+				swup.hooks.callSync('scroll:start', {});
 				window.scrollTo(0, offset);
-				swup.hooks.callSync('scroll:end');
+				swup.hooks.callSync('scroll:end', {});
 			}
 		};
 


### PR DESCRIPTION
**Description**

I seemed to miss that swup always expects hook args now. @daun can you remember the reason for that?

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x]  The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)