### PR TITLE
feat: restore scroll positions after reload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export default class SwupScrollPlugin extends Plugin {
 		this.before('link:anchor', this.onBeforeLinkToAnchor, { priority: -1 });
 		this.replace('scroll:anchor', this.handleScrollToAnchor);
 
-		// store scroll container positions before unload
+		// store scroll positions between page reloads
 		window.addEventListener('beforeunload', this.onBeforeUnload);
 		this.restoreScrollPositionsFromHistoryState();
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,10 +398,17 @@ export default class SwupScrollPlugin extends Plugin {
 		const scrollPositions = window.history.state?.scrollPositions as
 			| ScrollPositions
 			| undefined;
-		if (scrollPositions?.window) {
+		if (scrollPositions?.window && this.validateScrollPosition(scrollPositions.window)) {
 			this.scrollTo({ ...scrollPositions.window }, false);
 		}
 		this.restoreScrollContainers(scrollPositions);
+	}
+
+	/**
+	 * Check if this is a valid scroll position
+	 */
+	validateScrollPosition(object: any): boolean {
+		return typeof object?.top === 'number' && typeof object?.left === 'number';
 	}
 
 	/**
@@ -415,7 +422,7 @@ export default class SwupScrollPlugin extends Plugin {
 		// cycle through all containers on the current page and restore their scroll positions, if appropriate
 		queryAll(this.options.scrollContainers).forEach((el, index) => {
 			const scrollPosition = scrollPositions.containers[index];
-			if (!scrollPosition) return;
+			if (!this.validateScrollPosition(scrollPosition)) return;
 			this.scrollTo({ ...scrollPosition }, false, el);
 		});
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,9 +398,11 @@ export default class SwupScrollPlugin extends Plugin {
 		const scrollPositions = window.history.state?.scrollPositions as
 			| ScrollPositions
 			| undefined;
+
 		if (scrollPositions?.window && this.validateScrollPosition(scrollPositions.window)) {
 			this.scrollTo({ ...scrollPositions.window }, false);
 		}
+
 		this.restoreScrollContainers(scrollPositions);
 	}
 

--- a/tests/e2e/tests/resetRestore.spec.ts
+++ b/tests/e2e/tests/resetRestore.spec.ts
@@ -61,4 +61,18 @@ test.describe('Reset & Restore', () => {
 		const target2 = page.getByTestId('both-axis_tile--last');
 		await expect(target2).toBeInViewport();
 	});
+
+	test('Restores the scroll positions after a page reload', async ({ page }) => {
+
+		await page.locator('[href="#both-axis_tile--last"]').click();
+		const target = page.getByTestId('both-axis_tile--last');
+		await expect(target).toHaveAttribute('data-swup-scroll-target', '');
+		await expect(target).toBeInViewport();
+
+		await page.reload();
+
+		const target2 = page.getByTestId('both-axis_tile--last');
+		await expect(target2).toHaveAttribute('data-swup-scroll-target', '');
+		await expect(target2).toBeInViewport();
+	});
 });


### PR DESCRIPTION
Alternative to #96 

**Description**

After a pretty deep rabbit hole with trying to keep the features (namely `shouldResetScrollPosition`) while fully switching to using the history state, I took a step back and implemented the feature that is missing for me the most currently:

Automatically restoring the scroll positions of the window as well as the scroll containers after a reload.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New tests included
- [ ] The documentation was updated as required

