### PR TITLE
Apply scroll position via custom scroll function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 A [swup](https://swup.js.org) plugin for customizable smooth scrolling.
 
-- Enables smooth scrolling
-- Animates scroll position between page visits
-- Animates scrolling to anchors
+- Enable smooth scrolling
+- Animate scroll position between page visits
+- Animate scrolling to anchors
 - Define a custom offset for scroll positions
 - Handle nested scroll containers
 - Emulate scroll target selector

--- a/README.md
+++ b/README.md
@@ -252,20 +252,24 @@ gsap.registerPlugin(ScrollToPlugin);
  * @see https://greensock.com/docs/v3/Plugins/ScrollToPlugin
  */
 
-new SwupScrollPlugin({
-  scrollFunction: (el, top, left, animate, start, end) => {
-    gsap.to(el, {
-      duration: animate ? 0.6 : 0,
-      ease: 'power4.out',
-      scrollTo: {
-        y: top,
-        x: left,
-        autoKill: !isTouch(),
-        onAutoKill: () => end()
+new Swup({
+  plugins: [
+    new SwupScrollPlugin({
+      scrollFunction: (el, top, left, animate, start, end) => {
+        gsap.to(el, {
+          duration: animate ? 0.6 : 0,
+          ease: "power4.out",
+          scrollTo: {
+            y: top,
+            x: left,
+            autoKill: window.matchMedia("(hover: hover)").matches,
+            onAutoKill: () => end(),
+          },
+          onStart: () => start(),
+          onComplete: () => end(),
+        });
       },
-      onStart: () => start(),
-      onComplete: () => end()
-    });
-  }
-})
+    }),
+  ]
+});
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
 
 A [swup](https://swup.js.org) plugin for customizable smooth scrolling.
 
-- Enables acceleration-based smooth scrolling
+- Enables smooth scrolling
 - Animates scroll position between page visits
 - Animates scrolling to anchors
 - Define a custom offset for scroll positions
+- Handle nested scroll containers
 - Emulate scroll target selector
 
 ## Installation

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,6 +476,7 @@ export default class SwupScrollPlugin extends Plugin {
 					() => {
 						el.scrollTo({
 							top: el.scrollTop,
+							left: el.scrollLeft,
 							behavior: 'instant'
 						});
 					},

--- a/src/index.ts
+++ b/src/index.ts
@@ -467,7 +467,8 @@ export default class SwupScrollPlugin extends Plugin {
 		start: () => void,
 		end: () => void
 	) {
-		const eventTarget = el instanceof HTMLHtmlElement ? window : el;
+		const eventTarget =
+			el instanceof HTMLHtmlElement || el instanceof HTMLBodyElement ? window : el;
 
 		// Dispatch the scroll:start hook immediately
 		start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -451,7 +451,7 @@ export default class SwupScrollPlugin extends Plugin {
 		const start = () => this.swup.hooks.callSync('scroll:start', visit, undefined);
 		const end = () => this.swup.hooks.callSync('scroll:end', visit, undefined);
 
-		// Appl scroll via user-supplied scroll function or default one
+		// Apply scroll via user-supplied scroll function or default one
 		const scrollFunction = this.options.scrollFunction ?? this.applyScroll;
 		scrollFunction(scrollContainer, top, left, animate, start, end);
 	}

--- a/tests/unit/tests/options.test.ts
+++ b/tests/unit/tests/options.test.ts
@@ -1,32 +1,67 @@
-import { describe, expect, it } from 'vitest';
-import { JSDOM } from 'jsdom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ScrollPlugin from '../../../src/index.js';
+import Swup, { Visit } from 'swup';
 
 describe('Options', () => {
+	let swup: Swup;
+	let plugin: ScrollPlugin;
+	let visit: Visit;
+
+	beforeEach(() => {
+		document.body.innerHTML = '<h1>Test</h1>';
+
+		swup = new Swup();
+
+		// @ts-ignore - createVisit is marked internal
+		visit = swup.createVisit({ url: '/' });
+		visit.to.document = new window.DOMParser().parseFromString(
+			'<html><head></head><body></body></html>',
+			'text/html'
+		);
+	});
+
 	it('should respect animateScroll', () => {
-		const scrollPlugin = new ScrollPlugin({
+		plugin = new ScrollPlugin({
 			animateScroll: {
 				betweenPages: false,
 				samePage: false,
 				samePageWithHash: false
 			}
 		});
-		expect(scrollPlugin.shouldAnimate('betweenPages')).toBe(false);
-		expect(scrollPlugin.shouldAnimate('samePage')).toBe(false);
-		expect(scrollPlugin.shouldAnimate('samePageWithHash')).toBe(false);
+		swup.use(plugin);
+
+		expect(plugin.shouldAnimate('betweenPages')).toBe(false);
+		expect(plugin.shouldAnimate('samePage')).toBe(false);
+		expect(plugin.shouldAnimate('samePageWithHash')).toBe(false);
 	});
 
 	it('should always return an object from getOffset', () => {
-		const scrollPlugin = new ScrollPlugin({
-			offset: 300
-		});
+		plugin = new ScrollPlugin({ offset: 300 });
+		swup.use(plugin);
 
-		const offset = scrollPlugin.getOffset(
+		const offset = plugin.getOffset(
 			document.createElement('div'),
 			document.createElement('div'),
 			{ left: 0, top: 0 }
 		);
 
 		expect(offset).toEqual({ left: 0, top: 300 });
+	});
+
+	it('should call custom scroll function', () => {
+		const scrollFunction = vi.fn();
+		plugin = new ScrollPlugin({ scrollFunction });
+		swup.use(plugin);
+
+		plugin.scrollTo({ top: 300, left: 50 }, true);
+
+		expect(scrollFunction).toHaveBeenCalledWith(
+			document.documentElement,
+			300,
+			50,
+			true,
+			expect.any(Function),
+			expect.any(Function)
+		);
 	});
 });

--- a/tests/unit/vitest.config.ts
+++ b/tests/unit/vitest.config.ts
@@ -11,6 +11,12 @@ const __dirname = path.dirname(__filename);
 export default defineConfig({
 	test: {
 		environment: 'jsdom',
+		environmentOptions: {
+			jsdom: {
+				console: true,
+				resources: 'usable'
+			}
+		},
 		include: ['tests/unit/tests/*.test.ts'],
 		setupFiles: [path.resolve(__dirname, './vitest.setup.ts')]
 	}

--- a/tests/unit/vitest.config.ts
+++ b/tests/unit/vitest.config.ts
@@ -11,12 +11,6 @@ const __dirname = path.dirname(__filename);
 export default defineConfig({
 	test: {
 		environment: 'jsdom',
-		environmentOptions: {
-			jsdom: {
-				console: true,
-				resources: 'usable'
-			}
-		},
 		include: ['tests/unit/tests/*.test.ts'],
 		setupFiles: [path.resolve(__dirname, './vitest.setup.ts')]
 	}

--- a/tests/unit/vitest.setup.ts
+++ b/tests/unit/vitest.setup.ts
@@ -1,6 +1,6 @@
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
-// Stub browser functions for vitest
-// console.log = vi.fn();
-// console.warn = vi.fn();
-// console.error = vi.fn();
+afterEach(() => {
+	document.body.innerHTML = '';
+	vi.clearAllMocks();
+});


### PR DESCRIPTION
**Description**

- Create a slightly less hacky way of replacing the internal scroll implementation
- New `scrollFunction` option for passing in a custom scroll implementation
- The element itself needs to be supplied, as well as both top and left position
- Triggering the `scroll:start` and `scroll:end` hooks happens by calling two supplied functions from the args
- Needs new tests and docs

**Usage example**

```js
new SwupScrollPlugin({
  scrollFunction: (el, top, left, animate, start, end) => {
    gsap.to(el, {
      duration: animate ? 0.6 : 0,
      ease: 'power4.out',
      scrollTo: {
        y: top,
        x: left,
        autoKill: !isTouch(),
        onAutoKill: () => end()
      },
      onStart: () => start(),
      onComplete: () => end()
    });
  }
})
```

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required
